### PR TITLE
Harden config load/persistence against reset scenarios

### DIFF
--- a/tSIP/FormMain.cpp
+++ b/tSIP/FormMain.cpp
@@ -409,7 +409,11 @@ void TfrmMain::InitButtons(void)
 	asButtonsFile.sprintf("%s\\%s_buttons.json", Paths::GetProfileDir().c_str(),
 		ChangeFileExt(ExtractFileName(Application->ExeName), "").c_str());
 	buttons.SetFilename(asButtonsFile);
-	buttons.Read();
+	int btnReadStatus = buttons.Read();
+	if (btnReadStatus != 0)
+	{
+		LOG("Failed to read button configuration (status = %d), existing file was left unchanged\n", btnReadStatus);
+	}
 	buttons.UpdateContacts(appSettings.uaConf.contacts);
 
 	buttons.SetScalingPercentage(appSettings.gui.scalingPct);
@@ -535,7 +539,10 @@ void TfrmMain::Finalize(void)
 	appSettings.Logging.windowWidth = frmLog->Width;
 	appSettings.Logging.windowHeight = frmLog->Height;
 
-	appSettings.Write(Paths::GetConfig());
+	if (appSettings.Write(Paths::GetConfig()) != 0)
+	{
+		LOG("Failed to write main configuration\n");
+	}
 	if (appSettings.history.noStoreToFile == false)
 	{
 		history.Write();
@@ -739,7 +746,10 @@ void TfrmMain::UpdateSettings(const Settings &prev)
 	tmrScript2->Interval = appSettings.Scripts.timer2;
 	tmrScript2->Enabled = true;
 
-	appSettings.Write(Paths::GetConfig());
+	if (appSettings.Write(Paths::GetConfig()) != 0)
+	{
+		LOG("Failed to write main configuration\n");
+	}
 }
 
 int TfrmMain::UpdateButtonsFromJson(AnsiString json)
@@ -1219,7 +1229,10 @@ int TfrmMain::OnPluginEnable(const char* dllName, bool state)
 	if (changed)
 	{
 		PhoneInterface::SetCfg(appSettings.phoneConf);
-		appSettings.Write(Paths::GetConfig());
+		if (appSettings.Write(Paths::GetConfig()) != 0)
+		{
+			LOG("Failed to write main configuration\n");
+		}
 		return 0;
 	}
 	return -1;
@@ -3051,7 +3064,10 @@ void TfrmMain::OnProgrammableBtnClick(int id, TProgrammableButton* btn)
 			appSettings.uaConf.autoAnswerReason = cfg.sipReason;
 			UpdateAutoAnswer();
 		}
-		appSettings.Write(Paths::GetConfig());		
+		if (appSettings.Write(Paths::GetConfig()) != 0)
+		{
+			LOG("Failed to write main configuration\n");
+		}
 		break;
 	case Button::ZRTP_VERIFY_SAS:
 		UA->ZrtpVerifySas(true);

--- a/tSIP/Settings.cpp
+++ b/tSIP/Settings.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <fstream>
 #include <json/json.h>
+#include <windows.h>
 
 //---------------------------------------------------------------------------
 
@@ -128,6 +129,8 @@ Settings::_Branding::_Branding(void):
 
 Settings::Settings(void)
 {
+	configWriteAllowed = true;
+
 	Display.bUserOnlyClip = false;
 	Display.bDecodeUtfDisplayToAnsi = false;
 	Display.bUsePAssertedIdentity = false;
@@ -206,18 +209,57 @@ int Settings::Read(AnsiString asFileName)
 
 	try
 	{
-		std::ifstream ifs(asFileName.c_str());
+		std::ifstream ifs(asFileName.c_str(), std::ios::in | std::ios::binary);
+		if (!ifs.is_open())
+		{
+			return READ_FILE_NOT_FOUND;
+		}
 		std::string strConfig((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
 		ifs.close();
+		if (strConfig.empty())
+		{
+			return READ_EMPTY_FILE;
+		}
 		bool parsingSuccessful = reader.parse( strConfig, root );
 		if ( !parsingSuccessful )
 		{
-			return 2;
+			AnsiString backupFile = asFileName + ".bak";
+			std::ifstream ifsBackup(backupFile.c_str(), std::ios::in | std::ios::binary);
+			if (!ifsBackup.is_open())
+			{
+				return READ_PARSE_ERROR;
+			}
+			std::string strConfigBackup((std::istreambuf_iterator<char>(ifsBackup)), std::istreambuf_iterator<char>());
+			ifsBackup.close();
+			if (strConfigBackup.empty())
+			{
+				return READ_PARSE_ERROR;
+			}
+			parsingSuccessful = reader.parse(strConfigBackup, root);
+			if (!parsingSuccessful)
+			{
+				return READ_PARSE_ERROR;
+			}
+			if (root.type() != Json::objectValue)
+			{
+				return READ_INVALID_ROOT;
+			}
+			int rc = UpdateFromJsonValue(root);
+			if (rc != 0)
+			{
+				return rc;
+			}
+			return READ_RECOVERED_FROM_BACKUP;
 		}
 	}
 	catch(...)
 	{
-		return 1;
+		return READ_IO_ERROR;
+	}
+
+	if (root.type() != Json::objectValue)
+	{
+		return READ_INVALID_ROOT;
 	}
 	
 	return UpdateFromJsonValue(root);
@@ -847,6 +889,11 @@ int Settings::UpdateFromJsonValue(const Json::Value &root)
 
 int Settings::Write(AnsiString asFileName)
 {
+	if (!configWriteAllowed)
+	{
+		return 2;
+	}
+
 	Json::Value root;
 	Json::StyledWriter writer;
 
@@ -1190,9 +1237,41 @@ int Settings::Write(AnsiString asFileName)
 
 	try
 	{
-		std::ofstream ofs(asFileName.c_str());
-		ofs << outputConfig;
-		ofs.close();
+		AnsiString tmpFile = asFileName + ".tmp";
+		AnsiString backupFile = asFileName + ".bak";
+
+		FILE *fp = fopen(tmpFile.c_str(), "wb");
+		if (fp == NULL)
+		{
+			return 1;
+		}
+
+		int ret = fwrite(outputConfig.data(), outputConfig.size(), 1, fp);
+		fflush(fp);
+		fclose(fp);
+		if (ret != 1)
+		{
+			DeleteFile(tmpFile.c_str());
+			return 1;
+		}
+
+		if (FileExists(asFileName))
+		{
+			if (!ReplaceFile(asFileName.c_str(), tmpFile.c_str(), backupFile.c_str(),
+					REPLACEFILE_WRITE_THROUGH, NULL, NULL))
+			{
+				DeleteFile(tmpFile.c_str());
+				return 1;
+			}
+		}
+		else
+		{
+			if (!MoveFileEx(tmpFile.c_str(), asFileName.c_str(), MOVEFILE_WRITE_THROUGH | MOVEFILE_COPY_ALLOWED))
+			{
+				DeleteFile(tmpFile.c_str());
+				return 1;
+			}
+		}
 	}
 	catch(...)
 	{

--- a/tSIP/Settings.h
+++ b/tSIP/Settings.h
@@ -46,14 +46,32 @@ struct Font
 class Settings
 {
 private:
+	bool configWriteAllowed;
 	struct BrandingInitializer
 	{
 		BrandingInitializer(void);
 	} brandingInitializer;
 public:
+	enum ReadStatus
+	{
+		READ_OK = 0,
+		READ_IO_ERROR = 1,
+		READ_PARSE_ERROR = 2,
+		READ_INVALID_ROOT = 3,
+		READ_FILE_NOT_FOUND = 4,
+		READ_EMPTY_FILE = 5,
+		READ_RECOVERED_FROM_BACKUP = 6
+	};
+
 	int Read(AnsiString asFileName);
 	int Write(AnsiString asFileName);
 	int UpdateFromText(AnsiString text);
+	void SetConfigWriteAllowed(bool state) {
+		configWriteAllowed = state;
+	}
+	bool IsConfigWriteAllowed(void) const {
+		return configWriteAllowed;
+	}
 	struct _gui
 	{
 		enum { SCALING_MIN = 50 };

--- a/tSIP/buttons/ProgrammableButtons.cpp
+++ b/tSIP/buttons/ProgrammableButtons.cpp
@@ -22,6 +22,7 @@
 #include <fstream> 
 #include <json/json.h>
 #include <Forms.hpp>
+#include <windows.h>
 
 //---------------------------------------------------------------------------
 
@@ -192,12 +193,12 @@ int ProgrammableButtons::ReadFromString(AnsiString json)
 	bool parsingSuccessful = reader.parse( json.c_str(), root );
 	if ( !parsingSuccessful )
 	{
-		return 2;
+		return READ_PARSE_ERROR;
 	}
 
 	if (root.type() != Json::objectValue)
 	{
-		return 3;
+		return READ_INVALID_ROOT;
 	}
 
 	// assume this is newest configuration version if version is not present in text
@@ -219,18 +220,46 @@ int ProgrammableButtons::ReadFile(AnsiString name)
 
 	try
 	{
-		std::ifstream ifs(name.c_str());
+		std::ifstream ifs(name.c_str(), std::ios::in | std::ios::binary);
+		if (!ifs.is_open())
+		{
+			return READ_FILE_NOT_FOUND;
+		}
 		std::string strConfig((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
 		ifs.close();
+		if (strConfig.empty())
+		{
+			return READ_PARSE_ERROR;
+		}
 		bool parsingSuccessful = reader.parse( strConfig, root );
 		if ( !parsingSuccessful )
 		{
-			return 2;
+			AnsiString backupFile = name + ".bak";
+			std::ifstream ifsBackup(backupFile.c_str(), std::ios::in | std::ios::binary);
+			if (!ifsBackup.is_open())
+			{
+				return READ_PARSE_ERROR;
+			}
+			std::string strBackup((std::istreambuf_iterator<char>(ifsBackup)), std::istreambuf_iterator<char>());
+			ifsBackup.close();
+			if (strBackup.empty())
+			{
+				return READ_PARSE_ERROR;
+			}
+			parsingSuccessful = reader.parse(strBackup, root);
+			if (!parsingSuccessful)
+			{
+				return READ_PARSE_ERROR;
+			}
 		}
 	}
 	catch(...)
 	{
-		return 1;
+		return READ_IO_ERROR;
+	}
+	if (root.type() != Json::objectValue)
+	{
+		return READ_INVALID_ROOT;
 	}
 	return LoadFromJsonValue(root);
 }
@@ -240,7 +269,8 @@ int ProgrammableButtons::Read(void)
 	TimeCounter tc("Reading buttons configuration");
 	assert(filename != "");
 
-	if (ReadFile(filename) == 0)
+	int readStatus = ReadFile(filename);
+	if (readStatus == 0)
 	{
 		{
 			// regular log might not work yet - use OutputDebugString
@@ -256,7 +286,8 @@ int ProgrammableButtons::Read(void)
 
 		return 0;
 	}
-	else
+
+	if (readStatus == READ_FILE_NOT_FOUND)
 	{
 		// earlier versions stored btn config in main file - try to read it
 		AnsiString asConfigFile = ChangeFileExt( Application->ExeName, ".json" );
@@ -270,6 +301,8 @@ int ProgrammableButtons::Read(void)
 		Write();
 		return 0;
 	}
+
+	return readStatus;
 	//notifyObservers();
 }
 
@@ -300,19 +333,42 @@ int ProgrammableButtons::Write(void)
 	{
 		//TimeCounter tc("Writing buttons configuration file");
 		std::string outputConfig = writer.write( root );		// Debug: ~300 ms
-		FILE *fp = fopen(filename.c_str(), "wb");
+		AnsiString tmpFile = filename + ".tmp";
+		AnsiString backupFile = filename + ".bak";
+
+		FILE *fp = fopen(tmpFile.c_str(), "wb");
 		if (fp)
 		{
 			int ret = fwrite(outputConfig.data(), outputConfig.size(), 1, fp);
+			fflush(fp);
 			fclose(fp);
 			if (ret != 1)
 			{
+				DeleteFile(tmpFile.c_str());
 				return 1;
 			}
 		}
 		else
 		{
 			return 1;
+		}
+
+		if (FileExists(filename))
+		{
+			if (!ReplaceFile(filename.c_str(), tmpFile.c_str(), backupFile.c_str(),
+					REPLACEFILE_WRITE_THROUGH, NULL, NULL))
+			{
+				DeleteFile(tmpFile.c_str());
+				return 1;
+			}
+		}
+		else
+		{
+			if (!MoveFileEx(tmpFile.c_str(), filename.c_str(), MOVEFILE_WRITE_THROUGH | MOVEFILE_COPY_ALLOWED))
+			{
+				DeleteFile(tmpFile.c_str());
+				return 1;
+			}
 		}
 	}
 

--- a/tSIP/buttons/ProgrammableButtons.h
+++ b/tSIP/buttons/ProgrammableButtons.h
@@ -75,6 +75,14 @@ public:
 	int Read(void);
 	int ReadFromString(AnsiString json);
 	int Write(void);
+	enum ReadStatus
+	{
+		READ_OK = 0,
+		READ_IO_ERROR = 1,
+		READ_PARSE_ERROR = 2,
+		READ_INVALID_ROOT = 3,
+		READ_FILE_NOT_FOUND = 4
+	};
 
 	enum { BASIC_PANEL_CONSOLE_BTNS = 15 };
 	enum { EXTRA_BTNS = 200 };

--- a/tSIP/tSIP.cpp
+++ b/tSIP/tSIP.cpp
@@ -90,7 +90,21 @@ WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 			ShowMessage("Failed to set path for current directory");
 		}
 
-		appSettings.Read(Paths::GetConfig());
+		int readStatus = appSettings.Read(Paths::GetConfig());
+		if (readStatus == Settings::READ_PARSE_ERROR || readStatus == Settings::READ_IO_ERROR ||
+			readStatus == Settings::READ_INVALID_ROOT || readStatus == Settings::READ_EMPTY_FILE)
+		{
+			appSettings.SetConfigWriteAllowed(false);
+			AnsiString msg;
+			msg.sprintf("Failed to load main config file.\n\nPath:\n%s\n\nAutomatic config writes are disabled for this run to avoid overwriting existing data.\nFix/restore config and restart application.", Paths::GetConfig().c_str());
+			ShowMessage(msg);
+		}
+		else if (readStatus == Settings::READ_RECOVERED_FROM_BACKUP)
+		{
+			AnsiString msg;
+			msg.sprintf("Main config file was invalid and was recovered from backup.\n\nPath:\n%s", Paths::GetConfig().c_str());
+			ShowMessage(msg);
+		}
 		appSettings.UpdateFromText(Branding::fixedSettings);		
 
 		if (appSettings.frmMain.bUseCustomApplicationTitle)


### PR DESCRIPTION
## Summary
Hardens settings persistence/load flow to reduce risk of accidental reset after config file corruption or interrupted writes.

## Changes
- Added explicit read-status handling for main settings read path.
- Added startup handling in `tSIP.cpp`:
  - disables settings writes for current run on hard read failure,
  - reports recovery when backup was used.
- Main settings write path now uses temp-file write + `ReplaceFile(..., REPLACEFILE_WRITE_THROUGH, ...)`.
- Read fallback from `*.bak` when main settings parse fails.
- Buttons config:
  - read fallback from `*.bak` on parse failure,
  - migration to old location only when file is missing,
  - write path switched to temp-file write + `ReplaceFile`.
- Replaced magic numeric read-status returns in buttons code with named enum values.

## Notes
- This PR intentionally excludes unrelated fixes (off-by-one and profile-path save bug), now in separate PRs.
- The replacement logic does not force rollback to older backup on write failure.
